### PR TITLE
Fix: Display address properties in address step

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -80,11 +80,14 @@ angular
 
           setTimeout(function () {
             var schemaToUse;
-            if (toInspect === $scope.person) {
-              schemaToUse = schemas.person;
-            } else if (toInspect === $scope.person.address) {
-              schemaToUse = schemas.address;
-            } else if (toInspect === $scope.newChild) {
+
+            if (type === 'person') {
+              if (names && names.length === 1 && names[0] === 'address') {
+                schemaToUse = schemas.address;
+              } else {
+                schemaToUse = schemas.person;
+              }
+            } else if (type === 'newChild') {
               schemaToUse = schemas.child;
             }
 


### PR DESCRIPTION
The address step of the wizard was incorrectly displaying the person properties instead of the address properties.

This was caused by the logic in the `inspectionResultProcessors` which was checking `toInspect === $scope.person.address`. Debugging revealed that `toInspect` is always the root `person` object, and the property being inspected is indicated by the `names` parameter.

The fix is to use the `type` and `names` parameters to correctly identify and use the `address` schema when the `person.address` model is being inspected.